### PR TITLE
docs: local-dev walkthrough and accurate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,38 +5,76 @@ Staging environment links:
 CMS: https://cms.swinginhamburg.eins9und30.de/admin
 Website: https://swinginhamburg.eins9und30.de/de/
 
-## 🚀 Project Structure
+## Local development
 
-Inside of your Astro project, you'll see the following folders and files:
+The project has two parts: an Astro frontend at the repo root (npm) and a Payload CMS in `/cms` as a git submodule (pnpm, Postgres in Docker).
 
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+Requirements: Docker, Node ≥ 22.12, and pnpm (`npm i -g pnpm`).
+
+### One-time setup
+
+```bash
+# Check out the CMS submodule
+git submodule update --init --recursive
+
+# Install dependencies
+npm install
+(cd cms && pnpm install)
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+Create `cms/.env` (the bundled `cms/.env.example` is from the upstream template and references MongoDB — ignore it):
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+```
+DATABASE_URL=postgres://postgres:changeme@localhost:5432/postgres
+PAYLOAD_SECRET=any-random-string-for-local-dev
+```
 
-Any static assets, like images, can be placed in the `public/` directory.
+The credentials match the defaults in `cms/docker-compose.yml`.
 
-## 🧞 Commands
+### Running it
 
-All commands are run from the root of the project, from a terminal:
+Two terminals:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+```bash
+# Terminal 1 — CMS on http://localhost:3000
+cd cms
+pnpm run setup   # first run: starts Postgres, restores db-fixture.sql, runs next dev
+pnpm run dev     # subsequent runs
+```
 
-## 👀 Want to learn more?
+```bash
+# Terminal 2 — Astro frontend on http://localhost:4321
+npm run dev
+```
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+The frontend reads `PAYLOAD_URL` (default `http://localhost:3000`, see `src/utils.ts`), so no extra config is needed once the CMS is up. Open http://localhost:4321 (redirects to `/en`); the CMS admin is at http://localhost:3000/admin.
+
+If the database gets into a bad state, `pnpm run dev:clean` in `/cms` drops the Docker volume and re-seeds from the fixture.
+
+## Project structure
+
+```text
+.
+├── src/
+│   ├── pages/
+│   │   └── [locale]/        # /en and /de routes; / redirects to /en
+│   ├── components/          # Astro/React components, incl. RichText
+│   ├── styles/
+│   └── utils.ts             # PayloadSDK instance pointed at PAYLOAD_URL
+├── public/                  # static assets
+├── Dockerfile               # production image, served on port 4321
+└── cms/                     # Payload CMS (git submodule, separate package)
+```
+
+See [`AGENTS.md`](./AGENTS.md) for a fuller architecture overview and `cms/README.md` for CMS-specific details.
+
+## Frontend commands
+
+All commands are run from the repo root with npm. CMS commands live in `/cms` and use pnpm — see `cms/README.md`.
+
+| Command           | Action                                       |
+| :---------------- | :------------------------------------------- |
+| `npm install`     | Install dependencies                         |
+| `npm run dev`     | Start local dev server at `localhost:4321`   |
+| `npm run build`   | Build the production site to `./dist/`       |
+| `npm run preview` | Preview the build locally before deploying   |


### PR DESCRIPTION
## Summary
- Adds a **Local development** section walking through submodule init, the Postgres `.env`, and the two-terminal (CMS + Astro) workflow.
- Replaces the stale Astro boilerplate project tree (showed `src/pages/index.astro`, real layout is `src/pages/[locale]/`) with one that reflects reality and includes the `cms/` submodule.
- Scopes the commands table to the frontend and points readers at `cms/README.md` for CMS commands; drops the generic Astro "learn more" section.

Pairs with the docs cleanup in `nikplx/swinginhamburg-cms` (separate PR in the submodule repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)